### PR TITLE
Use monospace font for digits

### DIFF
--- a/APPlayMIDI/ViewController.swift
+++ b/APPlayMIDI/ViewController.swift
@@ -22,6 +22,9 @@ class ViewController: NSViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        currentTimeField.font = NSFont.monospacedDigitSystemFont(ofSize: 13, weight: .regular)
+        endTimeField.font = NSFont.monospacedDigitSystemFont(ofSize: 13, weight: .regular)
     }
 
     override func viewDidAppear() {


### PR DESCRIPTION
Just a simple fix for the time clock, so that the ":" character doesn't move around.